### PR TITLE
feat(task): retrieve task info for each staff under user [SPG-77]

### DIFF
--- a/backend/services/atomic/task/api/task.js
+++ b/backend/services/atomic/task/api/task.js
@@ -43,7 +43,7 @@ router.post("/new", async (req, res) => {
     }
   });
 
-router.get("/:user_id", async (req, res) => {
+  router.get("/by-user/:user_id", async (req, res) => {
     try {
         const inputUserId = req.params.user_id;
         const userTasks = await task.getTasksPerUser(inputUserId);
@@ -52,6 +52,20 @@ router.get("/:user_id", async (req, res) => {
     } catch (error) {
         res.status(500).json({ error: error.message });
     }
+});
+
+// POST /task/by-users { ids: ["u1","u2", ...] }
+router.post("/by-users", async (req, res) => {
+  try {
+    const ids = req.body?.ids;
+    if (!Array.isArray(ids)) {
+      return res.status(400).json({ error: "ids must be an array" });
+    }
+    const rows = await task.getTasksByUsers(ids);
+    res.status(200).json(rows);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
 });
 
 router.put("/edit/:task_id", async (req, res) => {

--- a/backend/services/atomic/task/model/task.js
+++ b/backend/services/atomic/task/model/task.js
@@ -1,6 +1,56 @@
 const { supabase } = require("../db/supabase");
 const taskTable = "task";
 
+// Accepted outputs: "Ongoing", "Under Review", "Completed", "Overdue"
+function normalizeStatus(input) {
+  if (!input) return null;
+
+  const s = String(input).trim().toLowerCase().replace(/[_-]+/g, " ");
+
+  // order matters; check the most specific first
+  if (/^under\s*review$/.test(s)) return "Under Review";
+  if (/^(completed|done)$/.test(s)) return "Completed";
+  if (/^(overdue)$/.test(s)) return "Overdue";
+  if (/^(ongoing|in\s*progress|pending)$/.test(s)) return "Ongoing";
+
+  // If it already matches, preserve original casing if provided,
+  // otherwise capitalize nicely as a fallback.
+  if (s === "ongoing") return "Ongoing";
+  if (s === "under review") return "Under Review";
+  if (s === "completed") return "Completed";
+  if (s === "overdue") return "Overdue";
+
+  // last resort: return the original input (lets Supabase error if invalid)
+  return input;
+}
+
+// helper
+async function getTasksByUsers(userIds = []) {
+  if (!Array.isArray(userIds) || userIds.length === 0) return [];
+
+  // Tasks where any of these users is the owner
+  const { data: ownerTasks, error: ownerError } = await supabase
+    .from(taskTable)
+    .select("id, title, deadline, status, owner, collaborators")
+    .in("owner", userIds)
+    .order("deadline", { ascending: true });
+  if (ownerError) throw new Error(ownerError.message);
+
+  // Tasks where any of these users is a collaborator (array column)
+  const { data: collabTasks, error: collabError } = await supabase
+    .from(taskTable)
+    .select("id, title, deadline, status, owner, collaborators")
+    .overlaps("collaborators", userIds);
+  if (collabError) throw new Error(collabError.message);
+
+  // Merge + de-dupe by id, sort by deadline asc
+  const all = [...(ownerTasks || []), ...(collabTasks || [])];
+  const map = new Map(all.map((t) => [t.id, t]));
+  return Array.from(map.values()).sort((a, b) =>
+    String(a.deadline || "").localeCompare(String(b.deadline || ""))
+  );
+}
+
 module.exports = {
 
     async getAllTasks() {
@@ -19,7 +69,7 @@ module.exports = {
             title: task.title,
             deadline: task.deadline,
             description: task.description,
-            status: task.status,
+            status: normalizeStatus(task.status),
             collaborators: task.collaborators,
             owner: task.owner,
             parent: task.parent
@@ -67,7 +117,7 @@ module.exports = {
                 title: updatedTask.title,
                 deadline: updatedTask.deadline,
                 description: updatedTask.description,
-                status: updatedTask.status,
+                status: normalizeStatus(updatedTask.status),
                 collaborators: updatedTask.collaborators,
                 owner: updatedTask.owner,
                 parent: updatedTask.parent
@@ -96,7 +146,7 @@ module.exports = {
         }
 
         return data;
-    }
-
+    },
+    getTasksByUsers,
 }
 

--- a/backend/services/atomic/task/test/SPG-23/task-put-edit.test.js
+++ b/backend/services/atomic/task/test/SPG-23/task-put-edit.test.js
@@ -15,7 +15,7 @@ describe('PUT /edit/:taskId', () => {
     };
 
     const res = await request(app)
-      .put(`/edit/${taskId}`)
+      .put(`/task/edit/${taskId}`)
       .send(updatedTask)
       .set('Content-Type', 'application/json');
 

--- a/backend/services/atomic/task/test/SPG-32/task-get-perUser.test.js
+++ b/backend/services/atomic/task/test/SPG-32/task-get-perUser.test.js
@@ -7,7 +7,7 @@ describe("GET /task/:user_id", () => {
 
     test("should retreive tasks related to user", async () => {
         const res = await request(app)
-            .get(`/task/${reqUserId}`)
+            .get(`/task/by-user/${reqUserId}`)
             .expect('Content-Type', 'application/json; charset=utf-8');
         
         expect(res.status).toBe(200);


### PR DESCRIPTION
- Add GET /task/by-user/:user_id (owner + collaborators)
- Add POST /task/by-users (batch)
- Normalize status strings to enum
- Fix PUT test path to /task/edit/:id"